### PR TITLE
Add paralleling processing for batch landmark extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ cd animeface-ruby
 ruby proc_folder.rb <input image folder> <output landmark file>
 ```
 
-Each of the lines in the `<output landmark file>` is a JSON string corresponding to a file in `<input image folder>`. 
+Each of the lines in the `<output landmark file>` is a JSON string corresponding to a file in `<input image folder>`.
 View the output file for more details.
+
+Alternatively, replace `proc_folder.rb` with `proc_folder_parallel.rb` leads to image processing in parallel.
+This requires Ruby package `parallel` and `ruby-progressbar`
 
 ## Create new dataset with animeface-ruby
 

--- a/animeface-ruby/proc_folder.rb
+++ b/animeface-ruby/proc_folder.rb
@@ -25,6 +25,7 @@ files.each do |file|
 
   image = Magick::ImageList.new(file)
   faces = AnimeFace::detect(image)
+  image.destroy!
 
   faces.each_with_index do |ctx, index|
     face = ctx["face"]

--- a/animeface-ruby/proc_folder_parallel.rb
+++ b/animeface-ruby/proc_folder_parallel.rb
@@ -23,6 +23,7 @@ output_file = ARGV[1]
 infoss = Parallel.map(files, progress: "Processing images...") do |file|
   image = Magick::ImageList.new(file)
   faces = AnimeFace::detect(image)
+  image.destroy!
 
   res = faces.map do |ctx|
     face = ctx["face"]

--- a/animeface-ruby/proc_folder_parallel.rb
+++ b/animeface-ruby/proc_folder_parallel.rb
@@ -1,0 +1,50 @@
+require "set"
+require 'json'
+require "rmagick"
+require_relative "AnimeFace"
+require "progress_bar"
+require "parallel"
+
+def get_box(thing)
+  keys = Set["x", "y", "width", "height"]
+  return thing.select { |key, value| keys.include? key }
+end
+
+if ARGV.size != 2
+  warn "Usage: #{$0} <dir_path> <output_file>"
+  exit(-1)
+end
+
+dir_path = ARGV[0]
+files = Dir["#{dir_path}/*"]
+
+output_file = ARGV[1]
+
+infoss = Parallel.map(files, progress: "Processing images...") do |file|
+  image = Magick::ImageList.new(file)
+  faces = AnimeFace::detect(image)
+
+  res = faces.map do |ctx|
+    face = ctx["face"]
+    left_eye = ctx["eyes"]["left"]
+    right_eye = ctx["eyes"]["right"]
+    mouth = ctx["mouth"]
+    likelihood = ctx["likelihood"]
+
+    info = {
+      "file" => "" + file,   # clone string object
+      "face" => get_box(face),
+      "left_eye" => get_box(left_eye),
+      "right_eye" => get_box(right_eye),
+      "mouth" => get_box(mouth),
+      "likelihood" => likelihood
+    }
+    info
+  end
+end
+
+fout = File.open(output_file, "w")
+infoss.flatten(1).each do |info|
+  fout << info.to_json
+  fout << "\n"
+end


### PR DESCRIPTION
Add paralleling processing for batch landmark extraction (folder of images).
Also fix a memory leak problem.